### PR TITLE
ci: fix "E: The repository 'http://dl.google.com/linux/chrome/deb stable InRelease' is not signed."

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,8 @@ jobs:
             # (base https://askubuntu.com/a/884900)
             set -x
             cd /tmp
+            # (from: https://askubuntu.com/a/771551/884249)
+            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
             sudo apt update
             sudo apt -y install build-essential nghttp2 libnghttp2-dev libssl-dev
             wget https://curl.haxx.se/download/curl-7.63.0.tar.gz


### PR DESCRIPTION
<img width="991" alt="image" src="https://user-images.githubusercontent.com/10933561/83366714-d1c1c300-a3eb-11ea-9196-fe8925267eff.png">
